### PR TITLE
Fix typos in ai_reporter

### DIFF
--- a/tools/ai_reporter.py
+++ b/tools/ai_reporter.py
@@ -92,8 +92,8 @@ Inputを読み、Outputの例を参考にして、**JSONだけ**を出力して�
 
 def check_json(word, mean, model, times=0):
     if times > 10:
-        print("[ERROR] faild 10 times")
-        raise ValueError("faild 10 times")
+        print("[ERROR] failed 10 times")
+        raise ValueError("failed 10 times")
     # プロンプトを実行してJSONを取得
     text = check_raw(word, mean, model)
     if "```" not in text:
@@ -154,7 +154,7 @@ def check(word, mean, model):
         #    continue
         # print(f"[{word}]=", json.dumps(obj, ensure_ascii=False))
         return obj
-    print("[ERROR] faild 10 times")
+    print("[ERROR] failed 10 times")
     return last_obj
 
 


### PR DESCRIPTION
## Summary
- fix misspelling `faild` → `failed` in `tools/ai_reporter.py`

## Testing
- `codespell -S src`


------
https://chatgpt.com/codex/tasks/task_e_683ffe5fdf1883288f8d72cb1e9760d3